### PR TITLE
deps: upgrade vite to 4.5.12

### DIFF
--- a/packages/bundler-vite/package.json
+++ b/packages/bundler-vite/package.json
@@ -34,7 +34,7 @@
     "postcss-preset-env": "7.5.0",
     "rollup-plugin-visualizer": "5.9.0",
     "systemjs": "^6.14.1",
-    "vite": "4.5.2"
+    "vite": "^4.5.12"
   },
   "devDependencies": {
     "@types/caniuse-lite": "1.0.5",


### PR DESCRIPTION
Vite 官方发布了 [4.5.12 修复文件系统安全问题](https://github.com/vitejs/vite/blob/v4.5.12/packages/vite/CHANGELOG.md#4512-2025-04-03)，更新依赖至该版本